### PR TITLE
 Make the veda staging hub homepage bootstrap5 compatible 

### DIFF
--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -23,6 +23,11 @@
     font-weight: bold;
 }
 
+[data-bs-theme="dark"] .lead {
+    color: lightgray;
+    font-weight: bold;
+}
+
 #new-user {
     font-weight: 600;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -103,7 +103,7 @@
               <button
                 type="button"
                 class="btn btn-primary"
-                data-dismiss="modal"
+                data-bs-dismiss="modal"
                 style="float: right"
               >
                 Close
@@ -160,6 +160,7 @@
         about
         <a
           href="https://nasa-impact.github.io/veda-docs/services/jupyterhub.html#getting-access-to-vedas-jupyterhub-environment"
+          class="text-decoration-none"
           target="_blank"
           rel="noopener"
         >


### PR DESCRIPTION
As 2i2c upgraded the hubs to use JupyerHub5, we also had to migrate any UI we were maintaining away from older bootstrap versions (<5) .

As part of this upgrade, the ghg staging and prod hubs were updated to use the https://github.com/2i2c-org/default-hub-homepage/tree/bootstrap5-nasa-veda-staging and https://github.com/2i2c-org/default-hub-homepage/tree/bootstrap5-nasa-veda-prod branches instead of pulling from this repository.

https://github.com/2i2c-org/infrastructure/issues/5368 has more context.

This PR just brings the changes from the branches mentioned above to this repository, so we can update the hubs to this repository again and remain bootrap5 compatible.