### PR TITLE
Update link to getting access guide

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -28,8 +28,8 @@ c.JupyterHub.template_vars = {
         "default_url": "/rstudio",
         "extra_css": "veda.css",
         "docs": {
-            "home": "https://nasa-impact.github.io/veda-docs/",
-            "access_request": "https://nasa-impact.github.io/veda-docs/services/jupyterhub.html#getting-access-to-vedas-jupyterhub-environment",
+            "home": "https://docs.openveda.cloud",
+            "access_request": "https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html",
         },
         "org": {
             "name": "The Visualization, Exploration, and Data Analysis (VEDA)",

--- a/templates/login.html
+++ b/templates/login.html
@@ -45,7 +45,7 @@
     </div>
     <div class="docs">
       <a
-        href="https://nasa-impact.github.io/veda-docs/"
+        href="{{ custom.docs.home }}"
         target="_blank"
         rel="noopener"
         style="text-decoration: none;"
@@ -159,7 +159,7 @@
         <span id="new-user"> New user? </span> Please see our documentation
         about
         <a
-          href="https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html"
+          href="{{ custom.docs.access_request }}"
           class="text-decoration-none"
           target="_blank"
           rel="noopener"

--- a/templates/login.html
+++ b/templates/login.html
@@ -159,7 +159,7 @@
         <span id="new-user"> New user? </span> Please see our documentation
         about
         <a
-          href="https://nasa-impact.github.io/veda-docs/services/jupyterhub.html#getting-access-to-vedas-jupyterhub-environment"
+          href="https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html"
           class="text-decoration-none"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
# Description
The "how to request access" link is broken because of some reorganization done in veda-docs, this PR updates the link to the correct url.