### PR TITLE
Hardcode docs urls

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -27,10 +27,6 @@ c.JupyterHub.template_vars = {
         "interface_selector": True,
         "default_url": "/rstudio",
         "extra_css": "veda.css",
-        "docs": {
-            "home": "https://docs.openveda.cloud",
-            "access_request": "https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html",
-        },
         "org": {
             "name": "The Visualization, Exploration, and Data Analysis (VEDA)",
             "url": "https://www.earthdata.nasa.gov/esds/veda",

--- a/templates/login.html
+++ b/templates/login.html
@@ -45,7 +45,7 @@
     </div>
     <div class="docs">
       <a
-        href="{{ custom.docs.home }}"
+        href="https://docs.openveda.cloud"
         target="_blank"
         rel="noopener"
         style="text-decoration: none;"
@@ -159,7 +159,7 @@
         <span id="new-user"> New user? </span> Please see our documentation
         about
         <a
-          href="{{ custom.docs.access_request }}"
+          href="https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html"
           class="text-decoration-none"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
# Description

The `jupyterhub_config.py` file is just for testing. The actual template vars comes from the cluster config in infrastructure repository https://infrastructure.2i2c.org/howto/features/login-page/

Removing the file to prevent confusion

And also hardcoding the URLs in the HTML page directly