### PR TITLE
fix: link to getting-access page

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -159,7 +159,7 @@
         <span id="new-user"> New user? </span> Please see our documentation
         about
         <a
-          href="https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html"
+          href="https://docs.openveda.cloud/user-guide/scientific-computing/getting-access.html"
           class="text-decoration-none"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
Hello 👋! I noticed that the link to the "getting access" user guide on the [VEDA Hub login page](https://hub.openveda.cloud/hub/login) was broken. It points to https://docs.openveda.cloud/nasa-veda-platform/scientific-computing/getting-access.html but it should be https://docs.openveda.cloud/user-guide/scientific-computing/getting-access.html

It looks like the link might've changed as part of https://github.com/NASA-IMPACT/veda-docs/pull/203.